### PR TITLE
Update configuration

### DIFF
--- a/theengsgateway/config.json
+++ b/theengsgateway/config.json
@@ -14,8 +14,8 @@
   "map": ["ssl:ro"],
   "options": {
     "MQTT_HOST": "localhost",
-    "MQTT_USERNAME": "user",
-    "MQTT_PASSWORD": "passwd",
+    "MQTT_USERNAME": "",
+    "MQTT_PASSWORD": "",
     "MQTT_PORT": 1883,
     "MQTT_PUB_TOPIC": "home/TheengsGateway/BTtoMQTT",
     "MQTT_SUB_TOPIC": "home/TheengsGateway/commands",

--- a/theengsgateway/config.json
+++ b/theengsgateway/config.json
@@ -13,7 +13,7 @@
   "host_dbus": true,
   "map": ["ssl:ro"],
   "options": {
-    "MQTT_HOST": "192.168.45.100",
+    "MQTT_HOST": "localhost",
     "MQTT_USERNAME": "user",
     "MQTT_PASSWORD": "passwd",
     "MQTT_PORT": 1883,
@@ -30,8 +30,8 @@
   },
   "schema": {
     "MQTT_HOST": "str",
-    "MQTT_USERNAME": "str",
-    "MQTT_PASSWORD": "str",
+    "MQTT_USERNAME": "str?",
+    "MQTT_PASSWORD": "str?",
     "MQTT_PORT": "int",
     "MQTT_PUB_TOPIC": "str?",
     "MQTT_SUB_TOPIC": "str?",


### PR DESCRIPTION
Change example IP by localhost as this will work OOB with most of the installations
Put the MQTT credentials as not compulsory for broker that doesn't requires credentials