### PR TITLE
[DOCS] Documentation fixes for black- and white-list

### DIFF
--- a/theengsgateway/DOCS.md
+++ b/theengsgateway/DOCS.md
@@ -18,8 +18,6 @@
 | MQTT_PUB_TOPIC        | string  | No       | MQTT publish topic, defaults to `home/TheengsGateway/BTtoMQTT`                  |
 | MQTT_SUB_TOPIC        | string  | No       | MQTT subscribe topic, defaults to `home/+/BTtoMQTT/undecoded`                   |
 | PRESENCE              | boolean | No       | Publish room presence detection, defaults to `no`                               |
-| GENERAL_PRESENCE      | boolean | No       | Publish general presence detection, defaults to `no`, 
-present/absent when --discovery: 0  |
 | MQTT_PRE_TOPIC        | string  | No       | MQTT presence topic, defaults to `home/presence/TheengsGateway`                 |
 | PUBLISH_ALL           | boolean | No       | Publish all beacons if true, defaults to `yes`                                  |
 | PUBLISH_ADVDATA       | boolean | No       | Publish advertisements data if true, defaults to `no`                           |
@@ -38,10 +36,10 @@ present/absent when --discovery: 0  |
 | SCANNING_MODE         | string  | No       | Change scanning mode between `active` and `passive`, defaults to `active`       |
 | TIME_SYNC             | string  | No       | Addresses of BLE devices to synchronize time (defaults to the empty list `[]`)  |
 | TIME_FORMAT           | boolean | No       | Use 12-hour (`yes`) or 24-hour (`no`) time format for clocks (defaults to `no`) |
-| IDENTITIES            | json    | No       | IRK to resolve private addresses, example { "00:11:22:33:44:55:66":"0dc540f3025b474b9ef1085e051b1add","AA:BB:CC:DD:EE:FF":"6385424e1b0341109942ad2a6bb42e58"}              |
-| BINDKEYS              | json    | No       | Addresses and key to decrypt data, example { "00:11:22:33:44:55:66":"0dc540f3025b474b9ef1085e051b1add","AA:BB:CC:DD:EE:FF":"6385424e1b0341109942ad2a6bb42e58"}              |
-| BLACKLIST            | json    | No       | Addresses of Bluetooth devices to ignore, all other devices are allowed, example { "00:11:22:33:44:55:66":"AA:BB:CC:DD:EE:FF"}              |
-| WHITELIST            | json    | No       | Addresses of Bluetooth devices to allow, all other devices are ignored, example { "00:11:22:33:44:55:66":"AA:BB:CC:DD:EE:FF"}              |
+| IDENTITIES            | json    | No       | IRK to resolve private addresses, example `{"00:11:22:33:44:55:66":"0dc540f3025b474b9ef1085e051b1add", "AA:BB:CC:DD:EE:FF":"6385424e1b0341109942ad2a6bb42e58"}`              |
+| BINDKEYS              | json    | No       | Addresses and key to decrypt data, example `{"00:11:22:33:44:55:66":"0dc540f3025b474b9ef1085e051b1add", "AA:BB:CC:DD:EE:FF":"6385424e1b0341109942ad2a6bb42e58"}`             |
+| BLACKLIST             | json    | No       | Addresses of Bluetooth devices to ignore, all other devices are allowed, example `["00:11:22:33:44:55:66", "AA:BB:CC:DD:EE:FF"]`              |
+| WHITELIST             | json    | No       | Addresses of Bluetooth devices to allow, all other devices are ignored, example `["00:11:22:33:44:55:66", "AA:BB:CC:DD:EE:FF"]`               |
 | TLS_INSECURE          | boolean | No       | Allow or disallow insecure TLS (no hostname check), defaults to 'no' (0)        |
 | ENABLE_TLS            | boolean | No       | Activate TLS                                                                    |
 | ENABLE_WEBSOCKET      | boolean | No       | Activate WebSocket                                                              |


### PR DESCRIPTION
• Removed GENERAL_PRESENCE from Documentation
• Corrected black- and white-list documentation with correct square brackets and commas, e. g.
 
`["00:11:22:33:44:55:66","AA:BB:CC:DD:EE:FF"]`
